### PR TITLE
adding python3 support for urllib and stringIO

### DIFF
--- a/utils/create_data.py
+++ b/utils/create_data.py
@@ -25,9 +25,9 @@ from __future__ import print_function
 from io import BytesIO
 import os
 import pickle
-import StringIO
+from io import StringIO
 import tarfile
-import urllib2
+from urllib.request import urlopen
 
 import keras.backend as K
 from keras.datasets import cifar10


### PR DESCRIPTION
Python 3 supports `from io import StringIO` and `from urllib.request import urlopen`.