### PR TITLE
Fixes random seeding

### DIFF
--- a/sampling_methods/kcenter_greedy.py
+++ b/sampling_methods/kcenter_greedy.py
@@ -102,7 +102,7 @@ class kCenterGreedy(SamplingMethod):
     new_batch = []
 
     for _ in range(N):
-      if self.already_selected is None:
+      if self.min_distances is None:
         # Initialize centers with a randomly selected datapoint
         ind = np.random.choice(np.arange(self.n_obs))
       else:


### PR DESCRIPTION
`self.already_selected` is initialized to `[]` in the constructor but is never assigned `None` so that will always be false.

If `already_selected` is empty, `ind` will be initialized to `np.argmax(self.min_distances)`, which was initialized to `None` and never reassigned so the first selected datapoint will always be `np.argmax(None) = 0`